### PR TITLE
Fixing an error in doNext

### DIFF
--- a/src/ofxPlaylist.cpp
+++ b/src/ofxPlaylist.cpp
@@ -198,6 +198,9 @@ bool ofxPlaylist::doNext(){
 
 	// don't do anything if you are requested to clear.
 	if (bShouldClear == true) return FALSE;
+	
+	// on a very fast application this can be empty
+	if (playlist.size() < 1) return FALSE;
 
 	for (int i=0; i<playlist.front()->size(); i++) {
 		// reset keyframe is_idle value, just in case it has been stored for re-use.


### PR DESCRIPTION
On a very fast application doNext can be called too often and pass through, resulting in an exception when we try to access the null iterator at the front of the empty deque
